### PR TITLE
Fix tooltip width and position when content change

### DIFF
--- a/src/interact.js
+++ b/src/interact.js
@@ -88,10 +88,10 @@
             this.currentPageX = e.pageX;
             this.currentPageY = e.pageY;
             this.currentEl = e.target;
+            this.updateDisplay();
             if (this.tooltip) {
                 this.tooltip.updatePosition(e.pageX, e.pageY);
             }
-            this.updateDisplay();
         },
 
         updateDisplay: function () {


### PR DESCRIPTION
When the tooltip is on the border right for sample, and the mouse pointer is moved over another region implying another wider content, a scollbar may appear. This is due to the computation of tooltips before the content update.

This PR ensures the size is computed after the content is updated.